### PR TITLE
adjusted sentinel1 provider for orbit and polarisation

### DIFF
--- a/esdl/providers/sentinel1.py
+++ b/esdl/providers/sentinel1.py
@@ -1,7 +1,6 @@
 import os
 from datetime import datetime
 import glob
-import netCDF4
 import numpy
 import re
 import datetime as dt
@@ -10,51 +9,57 @@ from esdl.cube_provider import NetCDFCubeSourceProvider
 
 
 class S1Provider(NetCDFCubeSourceProvider):
-    def __init__(self, cube_config, name='sentinel1', dir=None, resampling_order=None, polarisation=None):
-        super(S1Provider, self).__init__(cube_config, name, dir, resampling_order)
+
+    def __init__(self, cube_config, name='sentinel1', dir=None, resampling_order=None, polarisation=None, orbit=None):
+        super(S1Provider, self).__init__(
+            cube_config, name, dir, resampling_order)
         self.old_indices = None
         self.pol = polarisation
+        if orbit not in ['A', 'D']:
+            raise ValueError(
+                "Orbit must be 'A' (ascending) or 'D' (descending).")
+        self.orbit = orbit
+
     @property
     def variable_descriptors(self):
         return {
-            'sentinel1_{}'.format(self.pol): {
+            'sentinel1_{0}_{1}'.format(self.pol.lower(), self.orbit.lower()): {
                 'source_name': 'Band1',
                 'data_type': numpy.float32,
                 'fill_value': numpy.nan,
                 'units': 'bsi',
                 'long_name': 'Backscatter of Sentinel-1',
-                'standard_name': 'bsi_{}'.format(self.pol),
-                'references': 'Laeng, A., et al. "The ozone climate change initiative: Comparison of four '
-                              'Level-2 processors for the Michelson Interferometer for Passive Atmospheric '
-                              'Sounding (MIPAS)." Remote Sensing of Environment 162 (2015): 316-343.',
+                'standard_name': 'bsi_{0}_{1}'.format(self.pol, self.orbit),
+                'references': 'Copernicus Sentinel data 2018. Retrieved from '
+                + 'Copernicus Open Access Hub 2018, processed by ESA.',
                 'comment': '',
                 'url': '',
-                'project_name' : 'Copernicus',
+                'project_name': 'Copernicus',
             }
         }
 
     def compute_source_time_ranges(self):
-        file_names = glob.glob(self.dir_path + "/*" + self.pol + "*.nc")
-        print(self.dir_path + "/*" + self.pol + "*.nc")
+        print(self.dir_path)
+        print(os.path.expanduser(self.dir_path))
+        dir_path = os.path.realpath(os.path.expanduser(self.dir_path))
+        globpattern = os.path.join(
+            dir_path, "S1*_{0}_*_{1}_*.nc".format(self.orbit, self.pol))
+        file_paths = glob.glob(globpattern)
+        print(globpattern)
         source_time_ranges = list()
         date_pattern = re.compile('(\\d{8}T\\d{6})')
-        print(file_names)
-        for file_name in file_names:
-            if file_name[-3:] != ".nc":
-                continue
-            file = os.path.join(self.dir_path, file_name)
+        print(file_paths)
 
-            t1 = re.search(date_pattern, file_name).group()
-            print(t1)
-            dtobj = datetime.strptime(t1, "%Y%m%dT%H%M%S")
-            print(dtobj.tzinfo)
-            t2 = dtobj + dt.timedelta(hours=1)
+        for file_path in file_paths:
+            dtstr = re.search(date_pattern, file_path).group()
+            print(dtstr)
+            t1 = datetime.strptime(dtstr, "%Y%m%dT%H%M%S")
+            print(t1.tzinfo)
+            t2 = t1 + dt.timedelta(hours=1)
             print(t2)
 
-            source_time_ranges.append((dtobj,
-                                       t2,
-                                       file,
-                                       None))
+            source_time_ranges.append((t1, t2, file_path, None))
+
         return sorted(source_time_ranges, key=lambda item: item[0])
 
     def transform_source_image(self, source_image):
@@ -64,9 +69,8 @@ class S1Provider(NetCDFCubeSourceProvider):
         :return: source_image
         """
         # TODO (hans-permana, 20161219): the following line is a workaround to an issue where the nan values are
-        # always read as -9.9. Find out why these values are automatically converted and create a better fix.
+        # always read as -9.9. Find out why these values are automatically
+        # converted and create a better fix.
         source_image[source_image == -9.9] = numpy.nan
-        return numpy.roll(numpy.flipud(source_image), 180, axis=1)
 
-def finder(dir=".", pattern=""):
-    files = os.path.listdir(path)
+        return numpy.roll(numpy.flipud(source_image), 180, axis=1)

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,10 @@ setup(
         ],
         'esdl.source_providers': [
             'test = esdl.providers:TestCubeSourceProvider',
-            'sentinel1 = esdl.providers.sentinel1:S1Provider',
-            'sentinel1vv = esdl.providers.sentinel1:S1Provider',
+            'sentinel1_vh_a = esdl.providers.sentinel1:S1Provider',
+            'sentinel1_vh_d = esdl.providers.sentinel1:S1Provider',
+            'sentinel1_vv_a = esdl.providers.sentinel1:S1Provider',
+            'sentinel1_vv_d = esdl.providers.sentinel1:S1Provider',
             'burnt_area = esdl.providers.burnt_area:BurntAreaProvider',
             'c_emissions = esdl.providers.c_emissions:CEmissionsProvider',
             'ozone = esdl.providers.ozone:OzoneProvider',


### PR DESCRIPTION
Building on the Sentinel1 provider from branch [S1Prov](https://github.com/felixcremer/esdl-core/tree/S1Prov), I've changed the following things:
- added support for orbit (ascending, descending)
- autopep8'ed the Sentinel1 provider to adhere to PEP-8 (see README.rst)
- adjusted the metadata for Sentinel1 data
- made cube variable names lowercase, underscore-separated
- improved the file globbing (expanduser and realpath)
- made some minor readability tweaks for variable names in `compute_source_time_ranges`